### PR TITLE
Add component information

### DIFF
--- a/RMDashboard/Controllers/DataModel.cs
+++ b/RMDashboard/Controllers/DataModel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 
 namespace RMDashboard.Controllers
 {
@@ -13,6 +11,7 @@ namespace RMDashboard.Controllers
         public List<Stage> Stages;
         public List<Environment> Environments;
         public List<Step> ReleaseSteps;
+        public List<Component> ReleaseComponents;
     }
 
     public class Release
@@ -68,5 +67,13 @@ namespace RMDashboard.Controllers
         public int Id;
         public string Name;
         public string Description;
+    }
+
+    public class Component
+    {
+        public int ReleaseId;
+        public string TeamProject;
+        public string BuildDefinition;
+        public string Build;
     }
 }

--- a/RMDashboard/Controllers/ReleasesController.cs
+++ b/RMDashboard/Controllers/ReleasesController.cs
@@ -28,6 +28,7 @@ namespace RMDashboard.Controllers
                 // determine data-filters based on HTTP headers
                 string includedReleasePathIds = null;
                 int releaseCount = 5;
+                bool showComponents = true;
                 if (message.Headers.Contains("includedReleasePathIds"))
                 {
                     includedReleasePathIds = message.Headers.GetValues("includedReleasePathIds").First();
@@ -35,6 +36,10 @@ namespace RMDashboard.Controllers
                 if (message.Headers.Contains("releaseCount"))
                 {
                     releaseCount = Convert.ToInt32(message.Headers.GetValues("releaseCount").First());
+                }
+                if (message.Headers.Contains("showComponents"))
+                {
+                    showComponents = Convert.ToBoolean(message.Headers.GetValues("showComponents").First());
                 }
 
                 // retreive the data
@@ -88,15 +93,18 @@ namespace RMDashboard.Controllers
                     }
 
                     // components
-                    var components = data.ReleaseComponents
-                        .Where(c => c.ReleaseId == releaseData.Id)
-                        .OrderBy(c => c.BuildDefinition);
+                    if (showComponents)
+                    {                        
+                        var components = data.ReleaseComponents
+                            .Where(c => c.ReleaseId == releaseData.Id)
+                            .OrderBy(c => c.BuildDefinition);
 
-                    foreach (var componentData in components)
-                    {
-                        dynamic component = new ExpandoObject();
-                        release.components.Add(component);
-                        component.Build = componentData.Build;
+                        foreach (var componentData in components)
+                        {
+                            dynamic component = new ExpandoObject();
+                            release.components.Add(component);
+                            component.build = componentData.Build;
+                        }
                     }
                 }
 

--- a/RMDashboard/app/controllers/configController.js
+++ b/RMDashboard/app/controllers/configController.js
@@ -10,6 +10,7 @@ rmDashboardApp.controller('configController', ['$scope', 'releaseManagementServi
     $scope.config = {
         title: 'Release Management Dashboard',
         autoRefresh: true,
+        showComponents: true,
         refreshInterval: 300000,
         releaseCount: 5,
         theme: 'dark',

--- a/RMDashboard/app/services/releaseManagementService.js
+++ b/RMDashboard/app/services/releaseManagementService.js
@@ -19,7 +19,8 @@ rmDashboardApp.factory('releaseManagementService', ['$http', 'configService', fu
             if (config) {
                 req.headers = {
                     includedReleasePathIds: config.includedReleasePaths.toString(),
-                    releaseCount: config.releaseCount
+                    releaseCount: config.releaseCount,
+                    showComponents: config.showComponents
                 };
             }
 

--- a/RMDashboard/config.html
+++ b/RMDashboard/config.html
@@ -33,10 +33,7 @@
         </div>
         <div class="field">
             <div>Auto refresh:</div>
-            <select ng-model="config.autoRefresh">
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            <select ng-model="config.autoRefresh" ng-options="o.v as o.n for o in [{ n: 'No', v: false }, { n: 'Yes', v: true }]"></select>
         </div>
         <div class="field">
             <div>Refresh interval:</div>
@@ -57,6 +54,10 @@
                 <option value="1200000">20 minutes</option>
                 <option value="1800000">30 minutes</option>
             </select>
+        </div>
+        <div class="field">
+            <div>Show components</div>
+            <select ng-model="config.showComponents" ng-options="o.v as o.n for o in [{ n: 'No', v: false }, { n: 'Yes', v: true }]"></select>
         </div>
         <div class="field">
             <div>Number of releases to show:</div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -40,7 +40,7 @@
                         <div>{{stage.environment}}</div>
                         <div ng-repeat="step in stage.steps" class="step" step-status-style>
                             <div><strong>{{step.name}}</strong></div>
-                            <div>Started: {{step.createdOn | date:'hh:mm:ss'}}</div>
+                            <div>Started: {{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div>Status: {{step.status}}</div>
                         </div>
                     </div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -29,8 +29,9 @@
                 <div class="name">{{release.name}} - {{release.status}}</div>
                 <hr class="status-bar" release-status-style />
                 <div class="date">Started on: {{release.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
-                <div class="date">Components: 
-                    <div ng-repeat="component in release.components">{{component}}{{$last ? '' : ', '}}</div>
+                <div class="date" ng-show="release.components.length>0">
+                    Components:
+                    <div ng-repeat="component in release.components" style="display: inline">{{component.build}}{{$last ? '' : ', '}}</div>
                 </div>
                 <div class="date">Release Path: {{release.releasePathName}}</div>
                 <div ng-repeat="stage in release.stages" class="pipeline">

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -29,6 +29,9 @@
                 <div class="name">{{release.name}} - {{release.status}}</div>
                 <hr class="status-bar" release-status-style />
                 <div class="date">Started on: {{release.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
+                <div class="date">Components: 
+                    <div ng-repeat="component in release.components">{{component}}{{$last ? '' : ', '}}</div>
+                </div>
                 <div class="date">Release Path: {{release.releasePathName}}</div>
                 <div ng-repeat="stage in release.stages" class="pipeline">
                     <div class="stage">


### PR DESCRIPTION
Added the option to show the names of the components that are deployed in the pipeline.

The user used to connect to the database must have read-access to the following extra table:
  - ReleaseComponentV2


Added date and 24-hour notation to the deployment steps. Because the entire deployment might take multiple days.

Fixed issue with boolean databinding to selectbox.


![build_component screenshot](https://cloud.githubusercontent.com/assets/1440089/6258460/f736f1ce-b7c8-11e4-93cf-3aea26a9bd3f.png)
![untitled](https://cloud.githubusercontent.com/assets/1440089/6258537/a4ff8a82-b7c9-11e4-93b9-b395b4a1293f.png)

