### PR TITLE
Show detailed steps of deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The user used to connect to the database must have read-access to the following 
 - ReleaseStatus
 - ReleaseStepStatus
 - ReleaseV2
+- ReleaseV2ActivityLog
 - ReleaseV2Component
 - ReleaseV2StageWorkflow
 - ReleaseV2Step

--- a/RMDashboard.UnitTest/Controllers/ReleasesControllerTest.cs
+++ b/RMDashboard.UnitTest/Controllers/ReleasesControllerTest.cs
@@ -489,10 +489,10 @@ namespace RMDashboard.UnitTest.Controllers
 
         internal static void AssertAreDeploymentStepsEqual(DeploymentStep expectedDeploymentStep, dynamic actualDeploymentStep)
         {
-            Assert.AreEqual(expectedDeploymentStep.ActivityDisplayName, actualDeploymentStep.Name, "Unexpected name for deploymentstep");
-            Assert.AreEqual(expectedDeploymentStep.DateEnded, actualDeploymentStep.DateEnded, "Unexpected DateEnded for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
-            Assert.AreEqual(expectedDeploymentStep.DateStarted, actualDeploymentStep.DateStarted, "Unexpected DateStarted for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
-            Assert.AreEqual(expectedDeploymentStep.Status, actualDeploymentStep.Status, "Unexpected Status for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
+            Assert.AreEqual(expectedDeploymentStep.ActivityDisplayName, actualDeploymentStep.name, "Unexpected name for deploymentstep");
+            Assert.AreEqual(expectedDeploymentStep.DateEnded, actualDeploymentStep.dateEnded, "Unexpected DateEnded for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
+            Assert.AreEqual(expectedDeploymentStep.DateStarted, actualDeploymentStep.dateStarted, "Unexpected DateStarted for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
+            Assert.AreEqual(expectedDeploymentStep.Status, actualDeploymentStep.status, "Unexpected Status for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
         }
 
         internal static void AssertReleasesCollectionContainsRelease(List<dynamic> releases, Release expectedRelease)

--- a/RMDashboard.UnitTest/Controllers/ReleasesControllerTest.cs
+++ b/RMDashboard.UnitTest/Controllers/ReleasesControllerTest.cs
@@ -121,6 +121,11 @@ namespace RMDashboard.UnitTest.Controllers
                 .ForRelease(expectedRelease)
                 .ForStage(expectedStage)
                 .Build();
+            var expectedDeploymentStep = new DeploymentStepBuilder()
+                .ForRelease(expectedRelease)
+                .ForStage(expectedStage)
+                .ForStep(expectedStep)
+                .Build();
 
             var dataModel = new DataModelBuilder()
                 .WithRelease(expectedRelease)
@@ -128,6 +133,7 @@ namespace RMDashboard.UnitTest.Controllers
                 .WithStage(expectedStage)
                 .WithStageWorkflowFor(expectedRelease, expectedStage)
                 .WithStep(expectedStep)
+                .WithDeploymentStep(expectedDeploymentStep)
                 .Build();
 
             _releaseRepositoryMock.Setup((stub) => stub.GetReleaseData(It.IsAny<string>(), It.IsAny<int>()))
@@ -150,8 +156,13 @@ namespace RMDashboard.UnitTest.Controllers
             AssertAreStagesEqual(expectedStage, expectedEnvironment, actualStage);
 
             Assert.IsInstanceOfType(actualStage.steps, typeof(List<dynamic>), "Unexpected type for steps collection");
-            Assert.AreEqual(1, actualStage.steps.Count, "Unexpected number of steps for stage");
-            AssertAreStepsEqual(expectedStep, actualStage.steps[0]);
+            Assert.AreEqual(1, actualStage.steps.Count, "Unexpected number of steps for stage");            
+            var actualStep = actualStage.steps[0];
+            AssertAreStepsEqual(expectedStep, actualStep);
+
+            Assert.IsInstanceOfType(actualStep.deploymentSteps, typeof(List<dynamic>), "Unexpected type for deploymentStep collection");
+            Assert.AreEqual(1, actualStep.deploymentSteps.Count, "Unexpected number of steps for deploymentSteps");
+            AssertAreDeploymentStepsEqual(expectedDeploymentStep, actualStep.deploymentSteps[0]);
         }
 
         [TestMethod]
@@ -425,7 +436,7 @@ namespace RMDashboard.UnitTest.Controllers
             Assert.IsNotNull(result, "Unexpected result");
             Assert.IsNotNull(result.urlReleaseExplorer, "Unexpected url Release Explorer");
             Assert.AreNotEqual("", result.urlReleaseExplorer, "Unexpected url Release Explorer");
-        } 
+        }
 
         [TestMethod]
         public void Get_InvalidIncludedReleasePathIdsHeaderSpecified_BadRequestStatusReturned()
@@ -474,6 +485,14 @@ namespace RMDashboard.UnitTest.Controllers
             Assert.AreEqual(expectedStep.CreatedOn, actualStep.createdOn, "Unexpected createdOn for stage with id {0}", expectedStep.Id);
             Assert.AreEqual(expectedStep.Approver, actualStep.approver, "Unexpected approver for stage with id {0}", expectedStep.Id);
             Assert.AreEqual(expectedStep.IsAutomated, actualStep.isAutomated, "Unexpected approver for stage with id {0}", expectedStep.Id);
+        }
+
+        internal static void AssertAreDeploymentStepsEqual(DeploymentStep expectedDeploymentStep, dynamic actualDeploymentStep)
+        {
+            Assert.AreEqual(expectedDeploymentStep.ActivityDisplayName, actualDeploymentStep.Name, "Unexpected name for deploymentstep");
+            Assert.AreEqual(expectedDeploymentStep.DateEnded, actualDeploymentStep.DateEnded, "Unexpected DateEnded for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
+            Assert.AreEqual(expectedDeploymentStep.DateStarted, actualDeploymentStep.DateStarted, "Unexpected DateStarted for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
+            Assert.AreEqual(expectedDeploymentStep.Status, actualDeploymentStep.Status, "Unexpected Status for deploymentStep with name {0}", expectedDeploymentStep.ActivityDisplayName);
         }
 
         internal static void AssertReleasesCollectionContainsRelease(List<dynamic> releases, Release expectedRelease)

--- a/RMDashboard.UnitTest/RMDashboard.UnitTest.csproj
+++ b/RMDashboard.UnitTest/RMDashboard.UnitTest.csproj
@@ -78,6 +78,7 @@
     <Compile Include="TestHelpers\BuilderBase.cs" />
     <Compile Include="TestHelpers\ComponentBuilder.cs" />
     <Compile Include="TestHelpers\DataModelBuilder.cs" />
+    <Compile Include="TestHelpers\DeploymentStepBuilder.cs" />
     <Compile Include="TestHelpers\EnvironmentBuilder.cs" />
     <Compile Include="TestHelpers\GetReleasesHttpRequestMessageBuilder.cs" />
     <Compile Include="TestHelpers\ReleaseBuilder.cs" />

--- a/RMDashboard.UnitTest/TestHelpers/DataModelBuilder.cs
+++ b/RMDashboard.UnitTest/TestHelpers/DataModelBuilder.cs
@@ -13,6 +13,7 @@ namespace RMDashboard.UnitTest.TestHelpers
         private List<Step> _releaseSteps;
         private List<Stage> _stages;
         private List<StageWorkflow> _stageWorkflows;
+        private List<DeploymentStep> _deploymentSteps;
 
         public DataModelBuilder()
         {
@@ -22,6 +23,7 @@ namespace RMDashboard.UnitTest.TestHelpers
             _releases = new List<Release>();
             _releaseSteps = new List<Step>();
             _stages = new List<Stage>();
+            _deploymentSteps = new List<DeploymentStep>();
             _stageWorkflows = new List<StageWorkflow>();
         }
 
@@ -92,6 +94,12 @@ namespace RMDashboard.UnitTest.TestHelpers
             return this;
         }
 
+        public DataModelBuilder WithDeploymentStep(DeploymentStep deploymentStep)
+        {
+            _deploymentSteps.Add(deploymentStep);
+            return this;
+        }
+
         public DataModel Build()
         {
             return new DataModel()
@@ -103,6 +111,7 @@ namespace RMDashboard.UnitTest.TestHelpers
                 ReleaseSteps = _releaseSteps,
                 Stages = _stages,
                 StageWorkflows = _stageWorkflows,
+                DeploymentSteps = _deploymentSteps
             };
         }
     }

--- a/RMDashboard.UnitTest/TestHelpers/DeploymentStepBuilder.cs
+++ b/RMDashboard.UnitTest/TestHelpers/DeploymentStepBuilder.cs
@@ -1,0 +1,36 @@
+﻿using RMDashboard.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RMDashboard.UnitTest.TestHelpers
+{
+    class DeploymentStepBuilder : BuilderBase<Models.DeploymentStep>
+    {
+        internal DeploymentStepBuilder ForRelease(Release release)
+        {
+            if (release == null) throw new ArgumentNullException("release");
+
+            Fixture = Fixture.With((deploymentStep) => deploymentStep.ReleaseId, release.Id);
+            return this;
+        }
+
+        internal DeploymentStepBuilder ForStage(Stage stage)
+        {
+            if (stage == null) throw new ArgumentNullException("stage");
+
+            Fixture = Fixture.With((deploymentStep) => deploymentStep.StageId, stage.Id);
+            return this;
+        }
+
+        internal DeploymentStepBuilder ForStep(Step step)
+        {
+            if (step == null) throw new ArgumentNullException("step");
+
+            Fixture = Fixture.With((deploymentStep) => deploymentStep.ReleaseStepId, step.Id);
+            return this;
+        }
+    }
+}

--- a/RMDashboard/Controllers/ReleasesController.cs
+++ b/RMDashboard/Controllers/ReleasesController.cs
@@ -1,18 +1,16 @@
-﻿using System;
+﻿using RMDashboard.Models;
+using RMDashboard.Repositories;
+using RMDashboard.Validators;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Web.Http;
-using Dapper;
-using RMDashboard.Models;
-using RMDashboard.Repositories;
-using RMDashboard.Validators;
 using System.Reflection;
-using System.Diagnostics;
+using System.Web.Http;
 
 namespace RMDashboard.Controllers
 {
@@ -25,7 +23,8 @@ namespace RMDashboard.Controllers
 
         private const string URL_RELEASE_EXPLORER_KEY = "UrlReleaseExplorer";
 
-        public ReleasesController() : this(new ReleaseRepository())
+        public ReleasesController()
+            : this(new ReleaseRepository())
         {
         }
 
@@ -78,7 +77,7 @@ namespace RMDashboard.Controllers
                     // release
                     dynamic release = CreateRelease(releaseData);
                     result.releases.Add(release);
-                    
+
                     // stages
                     var stages = data.Stages
                         .Where(stage => data.StageWorkflows.Any(wf => wf.StageId == stage.Id && wf.ReleaseId == releaseData.Id))
@@ -88,22 +87,31 @@ namespace RMDashboard.Controllers
                         dynamic stage = CreateStage(stageData, data.Environments);
                         release.stages.Add(stage);
 
-                        // Steps
+                        // Steps and Deploymentsteps
                         stage.steps = new List<dynamic>();
                         var steps = data.ReleaseSteps
                             .Where(step => step.StageId == stageData.Id && step.ReleaseId == releaseData.Id)
                             .OrderBy(step => step.Attempt)
                             .ThenBy(step => step.StepRank);
+
                         foreach (var stepData in steps)
                         {
+                            var deploymentSteps = data.DeploymentSteps
+                                .Where(deploymentStep => deploymentStep.StageId == stageData.Id && deploymentStep.ReleaseId == releaseData.Id && deploymentStep.ReleaseStepId == stepData.Id)
+                                //If there is no StartDate then this step must be ordered at the bottom, not at the top
+                                .OrderBy(deploymentStep => deploymentStep.DateStarted == null ? 2 : 1)
+                                .ThenBy(deploymentStep => deploymentStep.DateStarted);
+                            
                             dynamic step = CreateStep(stepData);
-                            stage.steps.Add(step);
+                            step.deploymentSteps = CreateDeploymentSteps(deploymentSteps);
+
+                            stage.steps.Add(step);                            
                         }
                     }
 
                     // components
                     if (showComponents)
-                    {                        
+                    {
                         var components = data.ReleaseComponents
                             .Where(c => c.ReleaseId == releaseData.Id)
                             .OrderBy(c => c.BuildDefinition);
@@ -152,6 +160,24 @@ namespace RMDashboard.Controllers
             return stage;
         }
 
+        public static List<dynamic> CreateDeploymentSteps(IEnumerable<DeploymentStep> deploymentSteps)
+        {
+            List<dynamic> deploymentStepResultList = new List<dynamic>();
+
+            foreach(var deploymentStep in deploymentSteps)
+            {
+                dynamic deploymentStepResult = new ExpandoObject();
+                deploymentStepResult.Name = deploymentStep.ActivityDisplayName;
+                deploymentStepResult.DateEnded = deploymentStep.DateEnded;
+                deploymentStepResult.DateStarted = deploymentStep.DateStarted;
+                deploymentStepResult.Status = deploymentStep.Status;
+
+                deploymentStepResultList.Add(deploymentStepResult);
+            }
+
+            return deploymentStepResultList;
+        }
+
         private static dynamic CreateStep(Step stepData)
         {
             dynamic step = new ExpandoObject();
@@ -162,6 +188,7 @@ namespace RMDashboard.Controllers
             step.status = stepData.Status;
             step.rank = stepData.StepRank;
             step.createdOn = stepData.CreatedOn;
+            step.deploymentSteps = new List<dynamic>();
 
             return step;
         }
@@ -171,6 +198,5 @@ namespace RMDashboard.Controllers
             var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
             return fileVersionInfo.FileVersion;
         }
-
     }
 }

--- a/RMDashboard/Controllers/ReleasesController.cs
+++ b/RMDashboard/Controllers/ReleasesController.cs
@@ -167,10 +167,10 @@ namespace RMDashboard.Controllers
             foreach(var deploymentStep in deploymentSteps)
             {
                 dynamic deploymentStepResult = new ExpandoObject();
-                deploymentStepResult.Name = deploymentStep.ActivityDisplayName;
-                deploymentStepResult.DateEnded = deploymentStep.DateEnded;
-                deploymentStepResult.DateStarted = deploymentStep.DateStarted;
-                deploymentStepResult.Status = deploymentStep.Status;
+                deploymentStepResult.name = deploymentStep.ActivityDisplayName;
+                deploymentStepResult.dateEnded = deploymentStep.DateEnded;
+                deploymentStepResult.dateStarted = deploymentStep.DateStarted;
+                deploymentStepResult.status = deploymentStep.Status;
 
                 deploymentStepResultList.Add(deploymentStepResult);
             }

--- a/RMDashboard/Models/DataModel.cs
+++ b/RMDashboard/Models/DataModel.cs
@@ -11,6 +11,7 @@ namespace RMDashboard.Models
         public List<Stage> Stages;
         public List<Environment> Environments;
         public List<Step> ReleaseSteps;
+        public List<DeploymentStep> DeploymentSteps;
         public List<Component> ReleaseComponents;
     }
 
@@ -77,5 +78,16 @@ namespace RMDashboard.Models
         public string TeamProject;
         public string BuildDefinition;
         public string Build;
+    }
+
+    public class DeploymentStep
+    {
+        public int ReleaseId;
+        public int StageId;
+        public int ReleaseStepId;
+        public string ActivityDisplayName;
+        public string Status;
+        public DateTime? DateStarted;
+        public DateTime? DateEnded;
     }
 }

--- a/RMDashboard/RMDashboard.csproj
+++ b/RMDashboard/RMDashboard.csproj
@@ -80,6 +80,7 @@
     <Content Include="app\app.js" />
     <Content Include="app\controllers\configController.js" />
     <Content Include="app\controllers\overviewController.js" />
+    <Content Include="app\directives\deploymentstepStatusStyleDirective.js" />
     <Content Include="app\directives\stepStatusStyleDirective.js" />
     <Content Include="app\directives\releaseStatusStyleDirective.js" />
     <Content Include="app\services\configService.js" />

--- a/RMDashboard/Web.config
+++ b/RMDashboard/Web.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="ReleaseManagement" connectionString="Data Source=.\sqlexpress;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>		+    <add name="ReleaseManagement" connectionString="Data Source=demoenvtfs.cloudapp.net;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
+    <add name="ReleaseManagement" connectionString="Data Source=.\sqlexpress;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
   </connectionStrings>
   <appSettings>
     <add key="UrlReleaseExplorer" value="http://localhost:1000/ReleaseManagement/" />

--- a/RMDashboard/Web.config
+++ b/RMDashboard/Web.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="ReleaseManagement" connectionString="Data Source=demoenvtfs.cloudapp.net;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
+    <add name="ReleaseManagement" connectionString="Data Source=.\sqlexpress;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>		+    <add name="ReleaseManagement" connectionString="Data Source=demoenvtfs.cloudapp.net;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
   </connectionStrings>
   <appSettings>
     <add key="UrlReleaseExplorer" value="http://localhost:1000/ReleaseManagement/" />

--- a/RMDashboard/Web.config
+++ b/RMDashboard/Web.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="ReleaseManagement" connectionString="Data Source=.\sqlexpress;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
+    <add name="ReleaseManagement" connectionString="Data Source=demoenvtfs.cloudapp.net;Initial Catalog=ReleaseManagement;Persist Security Info=True;User ID=msrm_dashboard;Password=D@$hboard"/>
   </connectionStrings>
   <appSettings>
     <add key="UrlReleaseExplorer" value="http://localhost:1000/ReleaseManagement/" />

--- a/RMDashboard/app/controllers/overviewController.js
+++ b/RMDashboard/app/controllers/overviewController.js
@@ -3,7 +3,7 @@
 
     function OverviewController($interval, releaseManagementService, configService) {
         var vm = this;
-        var refreshInterval = 20000;
+        var refreshInterval = 90000;
         var autoRefresh = true;
 
         vm.title = "Release Management Dashboard";

--- a/RMDashboard/app/controllers/overviewController.js
+++ b/RMDashboard/app/controllers/overviewController.js
@@ -3,7 +3,7 @@
 
     function OverviewController($interval, releaseManagementService, configService) {
         var vm = this;
-        var refreshInterval = 90000;
+        var refreshInterval = 300000;
         var autoRefresh = true;
 
         vm.title = "Release Management Dashboard";

--- a/RMDashboard/app/directives/deploymentstepStatusStyleDirective.js
+++ b/RMDashboard/app/directives/deploymentstepStatusStyleDirective.js
@@ -1,0 +1,35 @@
+﻿(function (angular) {
+    'use strict';
+
+    /**
+    * This directive displays the status of a deploymentstep
+    */
+    function deploymentstepStatusStyle() {
+        function link($scope, element) {
+            switch ($scope.deploymentStep.status) {
+                case 'Pending':
+                    element.addClass("pending");
+                    break;
+                case 'In Progress':
+                    element.addClass("in-progress");
+                    break;
+                case 'Succeeded':
+                    element.addClass("succeeded");
+                    break;
+                case 'Failed':
+                    element.addClass("failed");
+                    break;
+                case 'Cancelled':
+                    element.addClass("cancelled");
+                    break;
+            }
+        }
+
+        return {
+            restrict: 'A',
+            link: link
+        }
+    }
+
+    angular.module('rmDashboardApp').directive('deploymentstepStatusStyle', deploymentstepStatusStyle);
+})(angular);

--- a/RMDashboard/assets/css/dark.css
+++ b/RMDashboard/assets/css/dark.css
@@ -41,9 +41,9 @@ body {
     float: right;
 }
 
-.menuitem a {    
-    margin-right: 25px;
-}
+    .menuitem a {
+        margin-right: 25px;
+    }
 
 .release {
     color: #2b4055;
@@ -55,16 +55,18 @@ body {
     border-radius: 10px;
     background-color: #aaaaaa;
 }
-    .name {
-        margin-left: 10px;
-        font-size: 175%;
-        font-weight: bold;
-    }
-    .date {
-        margin-left: 10px;
-        font-size: 125%;
-        font-weight: bold;
-    }
+
+.name {
+    margin-left: 10px;
+    font-size: 175%;
+    font-weight: bold;
+}
+
+.date {
+    margin-left: 10px;
+    font-size: 125%;
+    font-weight: bold;
+}
 
 .status-bar {
     border-radius: 2px;
@@ -186,19 +188,41 @@ body {
         text-decoration: none;
     }
 
-    .config-panel a:hover {
-        color: whitesmoke;
-        background-color: #1982db;
-    }
+        .config-panel a:hover {
+            color: whitesmoke;
+            background-color: #1982db;
+        }
 
 .field {
     margin: 10px;
 }
 
-.approver{
+.approver {
     font-style: italic;
 }
 
-.deploymentStep{
-    border-top: 2px solid #2b4055; 
+.deploymentStep {
+    border-radius: 5px;
+    font-style: italic;
+    margin: 5px;
 }
+
+    .deploymentStep.succeeded {
+        background-color: #CCFFB9;
+    }
+
+    .deploymentStep.failed {
+        background-color: #FF8C8C;
+    }
+
+    .deploymentStep.pending {
+        background-color: #FBFCFF;
+    }
+
+    .deploymentStep.in-progress {
+        background-color: #BECFFF;
+    }
+
+    .deploymentStep.cancelled {
+        background-color: #FFF645;
+    }

--- a/RMDashboard/assets/css/dark.css
+++ b/RMDashboard/assets/css/dark.css
@@ -198,3 +198,7 @@ body {
 .approver{
     font-style: italic;
 }
+
+.deploymentStep{
+    border-top: 2px solid #2b4055; 
+}

--- a/RMDashboard/assets/css/light.css
+++ b/RMDashboard/assets/css/light.css
@@ -41,9 +41,9 @@ body {
     float: right;
 }
 
-.menuitem a {    
-    margin-right: 25px;
-}
+    .menuitem a {
+        margin-right: 25px;
+    }
 
 .release {
     color: #2b4055;
@@ -55,16 +55,18 @@ body {
     background-color: #83c2ff;
     border-radius: 10px;
 }
-    .name {
-        margin-left: 10px;
-        font-size: 175%;
-        font-weight: bold;
-    }
-    .date {
-        margin-left: 10px;
-        font-size: 125%;
-        font-weight: bold;
-    }
+
+.name {
+    margin-left: 10px;
+    font-size: 175%;
+    font-weight: bold;
+}
+
+.date {
+    margin-left: 10px;
+    font-size: 125%;
+    font-weight: bold;
+}
 
 .status-bar {
     border-radius: 2px;
@@ -186,19 +188,41 @@ body {
         text-decoration: none;
     }
 
-    .config-panel a:hover {
-        color: whitesmoke;
-        background-color: #1982db;
-    }
+        .config-panel a:hover {
+            color: whitesmoke;
+            background-color: #1982db;
+        }
 
 .field {
     margin: 10px;
 }
 
-.approver{
+.approver {
     font-style: italic;
 }
 
-.deploymentStep{
-    border-top: 2px solid #2b4055; 
+.deploymentStep {
+    border-radius: 5px;
+    font-style: italic;
+    margin: 5px;
 }
+
+    .deploymentStep.succeeded {
+        background-color: #CCFFB9;
+    }
+
+    .deploymentStep.failed {
+        background-color: #FF8C8C;
+    }
+
+    .deploymentStep.pending {
+        background-color: #FBFCFF;
+    }
+
+    .deploymentStep.in-progress {
+        background-color: #BECFFF;
+    }
+
+    .deploymentStep.cancelled {
+        background-color: #FFF645;
+    }

--- a/RMDashboard/assets/css/light.css
+++ b/RMDashboard/assets/css/light.css
@@ -198,3 +198,7 @@ body {
 .approver{
     font-style: italic;
 }
+
+.deploymentStep{
+    border-top: 2px solid #2b4055; 
+}

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -45,6 +45,11 @@
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>
                             <div>Status : {{step.status}}</div>
+                            <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep">
+                                <div>{{deploymentStep.DateStarted | date:'HH:mm:ss'}}</div>
+                                <div>{{deploymentStep.Name}}</div>
+                                <div>{{deploymentStep.Status}}</div>
+                            </div>
                         </div>
                     </div>
                     <div class="stage-seperator" ng-class="{'last': $last}"></div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -15,6 +15,7 @@
     <script src="app/controllers/overviewController.js"></script>
     <script src="app/directives/releaseStatusStyleDirective.js"></script>
     <script src="app/directives/stepStatusStyleDirective.js"></script>
+    <script src="app/directives/deploymentStepStatusStyleDirective.js"></script>
 </head>
 <body>
     <div>
@@ -45,10 +46,10 @@
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>
                             <div>Status : {{step.status}}</div>
-                            <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep">
-                                <div>{{deploymentStep.DateStarted | date:'HH:mm:ss'}}</div>
-                                <div>{{deploymentStep.Name}}</div>
-                                <div>{{deploymentStep.Status}}</div>
+                            <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep" deploymentstep-status-style>
+                                <div>{{deploymentStep.dateStarted | date:'HH:mm:ss'}}</div>
+                                <div>{{deploymentStep.name}}</div>
+                                <div>{{deploymentStep.status}}</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Added option for showing the steps that are executed in the deployment step.

Example1:
![example1](https://cloud.githubusercontent.com/assets/1440089/7801926/1143602a-032d-11e5-94f7-05de45f428a3.png)

Example2:
![example2](https://cloud.githubusercontent.com/assets/1440089/7801929/18141c6e-032d-11e5-9cfa-ccd9a5b60893.png)

I also discovered that the data is refreshed every 20 seconds by default (when no cookie is set). I've changed this to 90 seconds. 