### PR TITLE
Track state off expanded deploymentSteps so after a refresh the screen won't be reset

### DIFF
--- a/RMDashboard/Controllers/ReleasesController.cs
+++ b/RMDashboard/Controllers/ReleasesController.cs
@@ -136,6 +136,7 @@ namespace RMDashboard.Controllers
         private static dynamic CreateRelease(Release releaseData)
         {
             dynamic release = new ExpandoObject();
+            release.id = releaseData.Id;
             release.name = releaseData.Name;
             release.status = releaseData.Status;
             release.createdOn = releaseData.CreatedOn;

--- a/RMDashboard/app/controllers/overviewController.js
+++ b/RMDashboard/app/controllers/overviewController.js
@@ -1,7 +1,7 @@
 ﻿(function (angular) {
     'use strict';
 
-    function OverviewController($interval, releaseManagementService, configService) {
+    function OverviewController($interval, $scope, $cacheFactory, releaseManagementService, configService) {
         var vm = this;
         var refreshInterval = 300000;
         var autoRefresh = true;
@@ -35,6 +35,24 @@
             }
         }
 
+        var cache = $cacheFactory('deploymentStepState');
+        $scope.put = function (key, stepStatus) {
+            if (stepStatus != 'Pending') {
+                var value = cache.get(key);
+                cache.put(key, value === undefined ? true : !value);
+            }
+        };
+        $scope.get = function (key, stepStatus) {
+            if (stepStatus != 'Pending') {
+                var value = cache.get(key);
+                return value === undefined ? false : value;
+            }
+            else {
+                return true;
+            }
+        };
+        
+
         /**
         * Loads the data from the API
         */
@@ -53,7 +71,7 @@
         };
     }
 
-    OverviewController.$inject = ['$interval', 'releaseManagementService', 'configService'];
+    OverviewController.$inject = ['$interval', '$scope', '$cacheFactory', 'releaseManagementService', 'configService'];
 
     angular.module('rmDashboardApp').controller('overviewController', OverviewController);
 })(angular);

--- a/RMDashboard/app/controllers/overviewController.js
+++ b/RMDashboard/app/controllers/overviewController.js
@@ -1,7 +1,7 @@
 ﻿(function (angular) {
     'use strict';
 
-    function OverviewController($interval, $scope, $cacheFactory, releaseManagementService, configService) {
+    function OverviewController($interval, $cacheFactory, releaseManagementService, configService) {
         var vm = this;
         var refreshInterval = 300000;
         var autoRefresh = true;
@@ -40,13 +40,13 @@
         * this prevents that the UI is changed to the initial state after a deployment refresh
         */
         var cache = $cacheFactory('deploymentStepState');
-        $scope.put = function (key, stepStatus) {
+        vm.put = function (key, stepStatus) {
             if (stepStatus != 'Pending') {
                 var value = cache.get(key);
                 cache.put(key, value === undefined ? true : !value);
             }
         };
-        $scope.get = function (key, stepStatus) {
+        vm.get = function (key, stepStatus) {
             if (stepStatus != 'Pending') {
                 var value = cache.get(key);
                 return value === undefined ? false : value;
@@ -55,10 +55,10 @@
                 return true;
             }
         };
-        $scope.determineShowDeploymentStepText = function (key, stepStatus) {
-            return stepStatus == 'Pending' ? '' : $scope.get(key, stepStatus) == true ? '-' : '+';
+        vm.determineShowDeploymentStepText = function (key, stepStatus) {
+            return stepStatus == 'Pending' ? '' : vm.get(key, stepStatus) == true ? '-' : '+';
         };
-        
+
 
         /**
         * Loads the data from the API
@@ -78,7 +78,7 @@
         };
     }
 
-    OverviewController.$inject = ['$interval', '$scope', '$cacheFactory', 'releaseManagementService', 'configService'];
+    OverviewController.$inject = ['$interval', '$cacheFactory', 'releaseManagementService', 'configService'];
 
     angular.module('rmDashboardApp').controller('overviewController', OverviewController);
 })(angular);

--- a/RMDashboard/app/controllers/overviewController.js
+++ b/RMDashboard/app/controllers/overviewController.js
@@ -35,6 +35,10 @@
             }
         }
 
+        /**
+        * Caching mechanism to keep track of the state of the collapsed deploymentSteps
+        * this prevents that the UI is changed to the initial state after a deployment refresh
+        */
         var cache = $cacheFactory('deploymentStepState');
         $scope.put = function (key, stepStatus) {
             if (stepStatus != 'Pending') {
@@ -50,6 +54,9 @@
             else {
                 return true;
             }
+        };
+        $scope.determineShowDeploymentStepText = function (key, stepStatus) {
+            return stepStatus == 'Pending' ? '' : $scope.get(key, stepStatus) == true ? '-' : '+';
         };
         
 

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -42,12 +42,12 @@
                         <div class="header">{{stage.name}}</div>
                         <div>{{stage.environment}}</div>
                         <div ng-repeat="step in stage.steps" class="step" step-status-style>
-                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" ng-click="showDeploymentSteps = !showDeploymentSteps">{{ (showDeploymentSteps || step.status == 'Pending') == true ? '-' : '+' }}</div>
+                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" ng-click="put([release.id, stage.id, step.id], step.status)" ng-bind="step.status == 'Pending' ? '' : get([release.id, stage.id, step.id], step.Status) == true ? '-' : '+'"></div>
                             <div><strong>{{step.name}}</strong></div>
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>
                             <div>Status : {{step.status}}</div>
-                            <div class="deploymentSteps" ng-show="showDeploymentSteps || step.status == 'Pending'">
+                            <div class="deploymentSteps" ng-show="get([release.id, stage.id, step.id], step.status)">
                                 <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep" deploymentstep-status-style>
                                     <div>{{deploymentStep.dateStarted | date:'HH:mm:ss'}}</div>
                                     <div>{{deploymentStep.name}}</div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -42,7 +42,10 @@
                         <div class="header">{{stage.name}}</div>
                         <div>{{stage.environment}}</div>
                         <div ng-repeat="step in stage.steps" class="step" step-status-style>
-                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" ng-click="put([release.id, stage.id, step.id], step.status)" ng-bind="step.status == 'Pending' ? '' : get([release.id, stage.id, step.id], step.Status) == true ? '-' : '+'"></div>
+                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" 
+                                 ng-click="put([release.id, stage.id, step.id], step.status)" 
+                                 ng-bind="determineShowDeploymentStepText([release.id, stage.id, step.id], step.Status)">
+                            </div>
                             <div><strong>{{step.name}}</strong></div>
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -43,14 +43,14 @@
                         <div>{{stage.environment}}</div>
                         <div ng-repeat="step in stage.steps" class="step" step-status-style>
                             <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" 
-                                 ng-click="put([release.id, stage.id, step.id], step.status)" 
-                                 ng-bind="determineShowDeploymentStepText([release.id, stage.id, step.id], step.Status)">
+                                 ng-click="vm.put([release.id, stage.id, step.id], step.status)" 
+                                 ng-bind="vm.determineShowDeploymentStepText([release.id, stage.id, step.id], step.Status)">
                             </div>
                             <div><strong>{{step.name}}</strong></div>
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>
                             <div>Status : {{step.status}}</div>
-                            <div class="deploymentSteps" ng-show="get([release.id, stage.id, step.id], step.status)">
+                            <div class="deploymentSteps" ng-show="vm.get([release.id, stage.id, step.id], step.status)">
                                 <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep" deploymentstep-status-style>
                                     <div>{{deploymentStep.dateStarted | date:'HH:mm:ss'}}</div>
                                     <div>{{deploymentStep.name}}</div>

--- a/RMDashboard/index.html
+++ b/RMDashboard/index.html
@@ -42,12 +42,12 @@
                         <div class="header">{{stage.name}}</div>
                         <div>{{stage.environment}}</div>
                         <div ng-repeat="step in stage.steps" class="step" step-status-style>
-                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" ng-click="showDeploymentSteps = ! showDeploymentSteps">{{ showDeploymentSteps == true ? '-' : '+' }}</div>
+                            <div ng-hide="!step.deploymentSteps.length" class="showDeploymentStepsLink" ng-click="showDeploymentSteps = !showDeploymentSteps">{{ (showDeploymentSteps || step.status == 'Pending') == true ? '-' : '+' }}</div>
                             <div><strong>{{step.name}}</strong></div>
                             <div>{{step.createdOn | date:'dd-MM-yyyy HH:mm:ss'}}</div>
                             <div ng-hide="step.isAutomated" class="approver">{{step.approver}}</div>
                             <div>Status : {{step.status}}</div>
-                            <div class="deploymentSteps" ng-show="showDeploymentSteps">
+                            <div class="deploymentSteps" ng-show="showDeploymentSteps || step.status == 'Pending'">
                                 <div ng-repeat="deploymentStep in step.deploymentSteps" class="deploymentStep" deploymentstep-status-style>
                                     <div>{{deploymentStep.dateStarted | date:'HH:mm:ss'}}</div>
                                     <div>{{deploymentStep.name}}</div>


### PR DESCRIPTION
I've added some extra logic to keep track of the state whenever a deploymentstep is expanded or not. I've used the built-in AngularJS cacheFactory for this.