### PR TITLE
Prevent deadlocks with isolationlevel + ordering of releasepaths on config page

### DIFF
--- a/RMDashboard/Controllers/ReleasePathsController.cs
+++ b/RMDashboard/Controllers/ReleasePathsController.cs
@@ -42,7 +42,7 @@ namespace RMDashboard.Controllers
                     return releasePath;
                 });
 
-                return result;
+                return result.OrderBy(r => r.name);
             }
             catch (Exception ex)
             {

--- a/RMDashboard/Repositories/ReleaseRepository.cs
+++ b/RMDashboard/Repositories/ReleaseRepository.cs
@@ -15,6 +15,8 @@ namespace RMDashboard.Repositories
             using (var connection = new SqlConnection(ConfigurationManager.ConnectionStrings["ReleaseManagement"].ConnectionString))
             {
                 var sql = @"
+                    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+
                     select	Id, 
                             Name, 
                             Description
@@ -50,6 +52,8 @@ namespace RMDashboard.Repositories
         private string GenerateSQL(int releaseCount, string includedReleasePathIds)
         {
             var sql = @"
+                    SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+
                     DECLARE @ScopedReleases TABLE
                     (
                        Id INT NOT NULL


### PR DESCRIPTION
Changed the isolation level to READ UNCOMMITTED which has the same result as the use of NOLOCK. This is to prevent deadlocks in the Release Management database.

Changed the order of the ReleasePaths on the config page. It is now sorted alphabetically.

