### PR TITLE
Fix when a url with subdirectory is used.

### DIFF
--- a/RMDashboard/config.html
+++ b/RMDashboard/config.html
@@ -75,8 +75,8 @@
             </div>
         </div>
         <div class="field">
-            <a href="/" ng-click="vm.saveConfig();">Save</a>
-            <a href="/">Cancel</a>
+            <a href="index.html" ng-click="vm.saveConfig();">Save</a>
+            <a href="index.html">Cancel</a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
For example http://localhost/RMDashboard

If you are on the config page and click the save button (url: http://localhost/RMDashboard/config.html). The following page is displayed when a subdirectory is used:
![rmdashboard](https://cloud.githubusercontent.com/assets/1440089/12145304/c517b76a-b48d-11e5-9429-4a2f76116fac.png).

With this pull request this will be fixed.
